### PR TITLE
build: Use package homepage url for metadata

### DIFF
--- a/{{cookiecutter.package_name}}/setup.cfg
+++ b/{{cookiecutter.package_name}}/setup.cfg
@@ -3,6 +3,7 @@ name = {{ cookiecutter.package_name }}
 author = {{ cookiecutter.full_name }}
 author_email = {{ cookiecutter.email }}
 description = {{ cookiecutter.package_short_description }}
+url = https://github.com/xyrha/{{ cookiecutter.package_name }}
 long_description = file:README.md
 long_description_content_type = text/markdown
 license = MIT


### PR DESCRIPTION
The url will automatically point to the GitHub
repository.